### PR TITLE
Add shop and product pages

### DIFF
--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -33,6 +33,9 @@ new class extends Component
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('shop')" :active="request()->routeIs('shop')" wire:navigate>
+                        {{ __('Shop') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -83,6 +86,9 @@ new class extends Component
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('shop')" :active="request()->routeIs('shop')" wire:navigate>
+                {{ __('Shop') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/livewire/product/product-show.blade.php
+++ b/resources/views/livewire/product/product-show.blade.php
@@ -1,5 +1,16 @@
-<div>
-    <h1 class="text-2xl font-bold mb-4">{{ $product->title }}</h1>
-    <p class="mb-2">Price: {{ $product->price }}</p>
-    <p class="mb-4">{{ $product->description }}</p>
-</div>
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ $product->title }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <p class="mb-2">Price: {{ $product->price }}</p>
+                <p class="mb-4">{{ $product->description }}</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/shop.blade.php
+++ b/resources/views/shop.blade.php
@@ -1,0 +1,24 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Shop') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                @forelse($products as $product)
+                    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                        <a href="{{ route('products.show', $product->slug) }}" wire:navigate>
+                            <h3 class="text-lg font-semibold mb-2">{{ $product->title }}</h3>
+                        </a>
+                        <p class="text-gray-600 dark:text-gray-400">${{ $product->price }}</p>
+                    </div>
+                @empty
+                    <p class="col-span-4 text-center text-gray-600 dark:text-gray-400">No products found.</p>
+                @endforelse
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,11 @@ Route::view('profile', 'profile')
     ->middleware(['auth'])
     ->name('profile');
 
+Route::get('/shop', function () {
+    $products = App\Models\Product::latest()->get();
+    return view('shop', ['products' => $products]);
+})->name('shop');
+
 require __DIR__.'/auth.php';
 
 Route::middleware(['auth', 'admin'])->group(function () {


### PR DESCRIPTION
## Summary
- add `shop` route to list products
- include shop links in navigation
- add Shop page blade file
- wrap product detail page in app layout

## Testing
- `composer install` *(fails: ext-dom and xml missing)*
- `vendor/bin/phpunit` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_684823b125dc832392f63bd9b93d4832