### PR TITLE
Add basic cart and checkout pages

### DIFF
--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -1,15 +1,14 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ $product->title }}
+            {{ __('Cart') }}
         </h2>
     </x-slot>
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6" data-aos="fade-up">
-                <p class="mb-2">Price: {{ $product->price }}</p>
-                <p class="mb-4">{{ $product->description }}</p>
+                <p class="text-gray-700 dark:text-gray-300">Your cart is empty.</p>
             </div>
         </div>
     </div>

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,15 +1,14 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ $product->title }}
+            {{ __('Checkout') }}
         </h2>
     </x-slot>
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6" data-aos="fade-up">
-                <p class="mb-2">Price: {{ $product->price }}</p>
-                <p class="mb-4">{{ $product->description }}</p>
+                <p class="text-gray-700 dark:text-gray-300">Checkout coming soon.</p>
             </div>
         </div>
     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,11 @@
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" />
+        <script defer src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
+        <script defer>
+            document.addEventListener('DOMContentLoaded', () => AOS.init());
+        </script>
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100 dark:bg-gray-900">

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -36,6 +36,12 @@ new class extends Component
                     <x-nav-link :href="route('shop')" :active="request()->routeIs('shop')" wire:navigate>
                         {{ __('Shop') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('cart')" :active="request()->routeIs('cart')" wire:navigate>
+                        {{ __('Cart') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('checkout')" :active="request()->routeIs('checkout')" wire:navigate>
+                        {{ __('Checkout') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -89,6 +95,12 @@ new class extends Component
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('shop')" :active="request()->routeIs('shop')" wire:navigate>
                 {{ __('Shop') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('cart')" :active="request()->routeIs('cart')" wire:navigate>
+                {{ __('Cart') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('checkout')" :active="request()->routeIs('checkout')" wire:navigate>
+                {{ __('Checkout') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/shop.blade.php
+++ b/resources/views/shop.blade.php
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                 @forelse($products as $product)
-                    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6" data-aos="fade-up">
                         <a href="{{ route('products.show', $product->slug) }}" wire:navigate>
                             <h3 class="text-lg font-semibold mb-2">{{ $product->title }}</h3>
                         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,9 @@ Route::get('/shop', function () {
     return view('shop', ['products' => $products]);
 })->name('shop');
 
+Route::view('/cart', 'cart')->name('cart');
+Route::view('/checkout', 'checkout')->name('checkout');
+
 require __DIR__.'/auth.php';
 
 Route::middleware(['auth', 'admin'])->group(function () {


### PR DESCRIPTION
## Summary
- add AOS animation library
- animate product cards and detail pages
- add `cart` and `checkout` pages
- link new pages in navigation
- define cart and checkout routes

## Testing
- `composer install`
- `php artisan migrate --force`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_684830297b788323b4bc26389694b4ba